### PR TITLE
Change weaveworks -> fluxcd

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -45,7 +45,7 @@ get_download_url() {
   local platform="$2"
   local filename="$(get_filename $version $platform)"
 
-  echo "https://github.com/weaveworks/flux/releases/download/${version}/${filename}"
+  echo "https://github.com/fluxcd/flux/releases/download/${version}/${filename}"
 }
 
 install_fluxctl $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH

--- a/bin/list-all
+++ b/bin/list-all
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-releases_path=https://api.github.com/repos/weaveworks/flux/releases
+releases_path=https://api.github.com/repos/fluxcd/flux/releases
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"


### PR DESCRIPTION
Flux joined the CNCF and the repository was moved out of the `weaveworks` organization, so the paths need to be updated... 